### PR TITLE
Add Render Deployment Configuration

### DIFF
--- a/RENDER_DEPLOYMENT.md
+++ b/RENDER_DEPLOYMENT.md
@@ -1,0 +1,23 @@
+# XMRT Eliza Deployment on Render
+
+## Overview
+This repository contains the XMRT DAO with Eliza AI integration, ready for deployment on Render.
+
+## Services
+1. **Frontend** - React-based UI for the XMRT DAO
+2. **AI Automation Service** - Eliza AI for autonomous operations
+3. **Backend API** - Core backend services
+
+## Deployment Steps
+1. Fork this repository to your own GitHub account
+2. Sign up for Render (https://render.com)
+3. Connect your GitHub account to Render
+4. Create a new Render Blueprint instance pointing to this repository
+5. Set up the required environment variables
+6. Deploy
+
+## Environment Variables
+See `.env.example` for the required environment variables.
+
+## Contact
+For assistance, contact: joeyleepcs@gmail.com

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,62 @@
+
+# Render YAML configuration for XMRT DAO with Eliza AI
+services:
+  # Frontend Service
+  - type: web
+    name: xmrt-eliza-frontend
+    runtime: node
+    buildCommand: cd frontend/xmrt-dao-frontend && pnpm install && pnpm run build
+    startCommand: cd frontend/xmrt-dao-frontend && npx serve -s dist -l $PORT
+    envVars:
+      - key: NODE_VERSION
+        value: 18
+      - key: PNPM_VERSION
+        value: 10.4.1
+      - fromGroup: xmrt-env-group
+
+  # AI Automation Service (Eliza)
+  - type: web
+    name: xmrt-eliza-ai
+    runtime: python
+    buildCommand: pip install -r backend/ai-automation-service/requirements.txt
+    startCommand: cd backend && python -m ai-automation-service.main
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11
+      - fromGroup: xmrt-env-group
+
+  # Main Backend API
+  - type: web
+    name: xmrt-backend-api
+    runtime: python
+    buildCommand: pip install -r backend/xmrt-dao-backend/requirements.txt
+    startCommand: cd backend && python -m xmrt-dao-backend.src.main
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11
+      - fromGroup: xmrt-env-group
+
+# Environment Variable Group
+envVarGroups:
+  - name: xmrt-env-group
+    envVars:
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: ETHEREUM_RPC_URL
+        sync: false
+      - key: WALLET_CONNECT_PROJECT_ID
+        sync: false
+      - key: VITE_API_BASE_URL
+        sync: false
+      - key: VITE_MOCK_API
+        value: true
+      - key: DATABASE_URL
+        sync: false
+      - key: MAX_AUTONOMOUS_VALUE
+        value: 10000
+      - key: CONFIDENCE_THRESHOLD
+        value: 0.8
+      - key: EMERGENCY_THRESHOLD
+        value: 0.95

--- a/setup_render_deployment.sh
+++ b/setup_render_deployment.sh
@@ -1,0 +1,42 @@
+
+#!/bin/bash
+# Setup script for XMRT Eliza deployment on Render
+
+# Create or update README for deployment
+cat > RENDER_DEPLOYMENT.md << 'EOL'
+# XMRT Eliza Deployment on Render
+
+## Overview
+This repository contains the XMRT DAO with Eliza AI integration, ready for deployment on Render.
+
+## Services
+1. **Frontend** - React-based UI for the XMRT DAO
+2. **AI Automation Service** - Eliza AI for autonomous operations
+3. **Backend API** - Core backend services
+
+## Deployment Steps
+1. Fork this repository to your own GitHub account
+2. Sign up for Render (https://render.com)
+3. Connect your GitHub account to Render
+4. Create a new Render Blueprint instance pointing to this repository
+5. Set up the required environment variables
+6. Deploy
+
+## Environment Variables
+See `.env.example` for the required environment variables.
+
+## Contact
+For assistance, contact: joeyleepcs@gmail.com
+EOL
+
+# Create a .render-buildpacks.json file for proper dependency installation
+cat > .render-buildpacks.json << 'EOL'
+{
+  "buildpacks": [
+    { "url": "heroku/nodejs" },
+    { "url": "heroku/python" }
+  ]
+}
+EOL
+
+echo "Repository has been prepared for Render deployment."


### PR DESCRIPTION
# Render Deployment Configuration

This PR adds the necessary configuration files to deploy the Eliza autonomous implementation to Render:

1. `render.yaml` - Blueprint for Render services
2. `setup_render_deployment.sh` - Setup script for deployment
3. `RENDER_DEPLOYMENT.md` - Documentation for deployment process

## Testing Instructions

1. Fork this repository
2. Sign up for Render (https://render.com)
3. Connect your GitHub account to Render
4. Create a new Blueprint instance pointing to this repository
5. Set up the required environment variables as per `.env.example`
6. Deploy the services

## Notes

- The deployment includes 3 services: frontend, AI automation (Eliza), and backend API
- All services are configured to use the same environment variable group
- Python 3.11 is specified for the backend services
- Node.js 18 is specified for the frontend service

Please review and merge to enable Render deployment capabilities.
